### PR TITLE
Small fix to OpenMM torsion assignment

### DIFF
--- a/openmm/ommstuff.cpp
+++ b/openmm/ommstuff.cpp
@@ -1678,12 +1678,18 @@ static void setupAmoebaTorsionForce (OpenMM_System* system, FILE* log) {
     OpenMM_DoubleArray* torsion1;
     OpenMM_DoubleArray* torsion2;
     OpenMM_DoubleArray* torsion3;
+    OpenMM_DoubleArray* torsion4;
+    OpenMM_DoubleArray* torsion5;
+    OpenMM_DoubleArray* torsion6;
 
     OpenMM_PeriodicTorsionForce* amoebaTorsionForce;
 
     torsion1 = OpenMM_DoubleArray_create(2);
     torsion2 = OpenMM_DoubleArray_create(2);
     torsion3 = OpenMM_DoubleArray_create(2);
+    torsion4 = OpenMM_DoubleArray_create(2);
+    torsion5 = OpenMM_DoubleArray_create(2);
+    torsion6 = OpenMM_DoubleArray_create(2);
 
     amoebaTorsionForce = OpenMM_PeriodicTorsionForce_create ();
     OpenMM_System_addForce (system, (OpenMM_Force*) amoebaTorsionForce);
@@ -1704,23 +1710,59 @@ static void setupAmoebaTorsionForce (OpenMM_System* system, FILE* log) {
         OpenMM_DoubleArray_set (torsion3, 0, torsunit*(*torsPtr));
         OpenMM_DoubleArray_set (torsion3, 1, acos((*(torsPtr+2))));
 
-        OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
-                  (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
-                  (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 1,
-                  OpenMM_DoubleArray_get (torsion1,1),
-                  OpenMM_DoubleArray_get (torsion1,0)); 
+        torsPtr = tors__.tors4 + ii*4;
+        OpenMM_DoubleArray_set (torsion4, 0, torsunit*(*torsPtr));
+        OpenMM_DoubleArray_set (torsion4, 1, acos((*(torsPtr+2))));
 
-        OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
-                  (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
-                  (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 2,
-                  OpenMM_DoubleArray_get(torsion2,1),
-                  OpenMM_DoubleArray_get(torsion2,0)); 
+        torsPtr = tors__.tors5 + ii*4;
+        OpenMM_DoubleArray_set (torsion5, 0, torsunit*(*torsPtr));
+        OpenMM_DoubleArray_set (torsion5, 1, acos((*(torsPtr+2))));
 
-        OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
-                  (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
-                  (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 3,
-                  OpenMM_DoubleArray_get(torsion3,1),
-                  OpenMM_DoubleArray_get(torsion3,0)); 
+        torsPtr = tors__.tors6 + ii*4;
+        OpenMM_DoubleArray_set (torsion6, 0, torsunit*(*torsPtr));
+        OpenMM_DoubleArray_set (torsion6, 1, acos((*(torsPtr+2))));
+
+        if (OpenMM_DoubleArray_get(torsion1, 0) != 0)
+            OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
+                      (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
+                      (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 1,
+                      OpenMM_DoubleArray_get (torsion1,1),
+                      OpenMM_DoubleArray_get (torsion1,0));
+
+        if (OpenMM_DoubleArray_get(torsion2, 0) != 0)
+            OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
+                      (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
+                      (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 2,
+                      OpenMM_DoubleArray_get(torsion2,1),
+                      OpenMM_DoubleArray_get(torsion2,0));
+
+        if (OpenMM_DoubleArray_get(torsion3, 0) != 0)
+            OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
+                      (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
+                      (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 3,
+                      OpenMM_DoubleArray_get(torsion3,1),
+                      OpenMM_DoubleArray_get(torsion3,0));
+
+        if (OpenMM_DoubleArray_get(torsion4, 0) != 0)
+            OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
+                      (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
+                      (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 4,
+                      OpenMM_DoubleArray_get(torsion4,1),
+                      OpenMM_DoubleArray_get(torsion4,0));
+
+        if (OpenMM_DoubleArray_get(torsion5, 0) != 0)
+            OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
+                      (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
+                      (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 5,
+                      OpenMM_DoubleArray_get(torsion5,1),
+                      OpenMM_DoubleArray_get(torsion5,0));
+
+        if (OpenMM_DoubleArray_get(torsion6, 0) != 0)
+            OpenMM_PeriodicTorsionForce_addTorsion (amoebaTorsionForce,
+                      (*torsIndexPtr) - 1, (*(torsIndexPtr+1)) - 1,
+                      (*(torsIndexPtr+2)) - 1, (*(torsIndexPtr+3)) - 1, 6,
+                      OpenMM_DoubleArray_get(torsion6,1),
+                      OpenMM_DoubleArray_get(torsion6,0));
 
         torsIndexPtr += 4;
     }
@@ -1728,6 +1770,9 @@ static void setupAmoebaTorsionForce (OpenMM_System* system, FILE* log) {
     OpenMM_DoubleArray_destroy (torsion1);
     OpenMM_DoubleArray_destroy (torsion2);
     OpenMM_DoubleArray_destroy (torsion3);
+    OpenMM_DoubleArray_destroy (torsion4);
+    OpenMM_DoubleArray_destroy (torsion5);
+    OpenMM_DoubleArray_destroy (torsion6);
 }
 
 static void setupAmoebaPiTorsionForce( OpenMM_System* system, FILE* log ) {

--- a/source/initial.f
+++ b/source/initial.f
@@ -15,10 +15,6 @@ c
 c     "initial" sets up original values for some parameters and
 c     variables that might not otherwise get initialized
 c
-c     note the calls below to "kmp_set" routines are only needed by
-c     the Intel compiler and must be commented for other compilers
-c
-c
       subroutine initial
       use sizes
       use align
@@ -81,8 +77,10 @@ c
 c
 c     Intel compiler extensions to OpenMP standard
 c
+#ifdef __INTEL_COMPILER
 !$    call kmp_set_stacksize_s (2**28)
 !$    call kmp_set_blocktime (0)
+#endif
 c
 c     values of machine precision constants
 c


### PR DESCRIPTION
Fix OpenMM torsion assignment for amoebabio09 FF (for nucleic acids). The 4-,
5-, and 6-fold torsions were not being added to the OpenMM System, and torsions
with these periodicities were defined for some nucleic acid systems. This commit
makes sure that those torsions are correctly added and adjusts the behavior of
adding torsions such that only torsions with non-zero force constants actually
get added.  This reduces the number of "useless" terms in the resulting OpenMM
System and makes debugging easier.

I also added a protective `#ifdef __INTEL_COMPILER` around the ifort-specific
OpenMP directives so that you don't have to keep changing the source code to
compile with ifort or gfortran.