### PR TITLE
Fix crashing NVE - return before thermostat

### DIFF
--- a/source/temper.f
+++ b/source/temper.f
@@ -62,8 +62,8 @@ c
 c     get the kinetic energy and instantaneous temperature
 c
       call kinetic (eksum,ekin)
-      if (.not. isothermal) return
       temp = 2.0d0 * eksum / (dble(nfree) * gasconst)
+      if (.not. isothermal) return
 c
 c     couple to external temperature bath via Berendsen scaling
 c

--- a/source/temper.f
+++ b/source/temper.f
@@ -62,6 +62,7 @@ c
 c     get the kinetic energy and instantaneous temperature
 c
       call kinetic (eksum,ekin)
+      if (.not. isothermal) return
       temp = 2.0d0 * eksum / (dble(nfree) * gasconst)
 c
 c     couple to external temperature bath via Berendsen scaling


### PR DESCRIPTION
Return from 'temper' subroutine before applying thermostat if using NVE.

Previously NVE crashed with NaNs originating from temperature scaling on line temper.f:101 under the default Bussi thermostat because the default value for 'kelvin' is -1 (set on dynamic.f:53).  Skipping thermostatting when not running isothermally fixes this.