### PR TITLE
OMM interface fix

### DIFF
--- a/openmm/dynamic_omm.f
+++ b/openmm/dynamic_omm.f
@@ -531,9 +531,9 @@ c
       call set_pme_data (nfft1,nfft2,nfft3,bsorder,igrid,bsmod1,
      &                   bsmod2,bsmod3,bsbuild,thetai1,thetai2,
      &                   thetai3,qgrid,qfac)
-      call set_polar_data (maxxtr,npolar,cxmax,cxtr,polarity,thole,
+      call set_polar_data (maxopt,npolar,coptmax,copt,polarity,thole,
      &                     pdamp,udir,udirp,udirs,udirps,uind,uinp,
-     &                     uinds,uinps,uxtr,uxtrp,uxtrs,uxtrps,
+     &                     uinds,uinps,uopt,uoptp,uopts,uoptps,
      &                     uexact,douind)
       call set_polgrp_data (maxp11,maxp12,maxp13,maxp14,np11,
      &                      np12,np13,np14,ip11,ip12,ip13,ip14)

--- a/openmm/ommstuff.cpp
+++ b/openmm/ommstuff.cpp
@@ -2798,12 +2798,10 @@ static void setupAmoebaMultipoleForce (OpenMM_System* system, FILE* log) {
       OpenMM_AmoebaMultipoleForce_setPolarizationType (amoebaMultipoleForce,
                                    OpenMM_AmoebaMultipoleForce_Direct);
    } else if (strncasecmp (polpot__.poltyp, "OPT", 3) == 0) {
-      optCoefficients = OpenMM_DoubleArray_create (5);
-      OpenMM_DoubleArray_set (optCoefficients, 0, polar__.copt[0]);
-      OpenMM_DoubleArray_set (optCoefficients, 1, polar__.copt[1]);
-      OpenMM_DoubleArray_set (optCoefficients, 2, polar__.copt[2]);
-      OpenMM_DoubleArray_set (optCoefficients, 3, polar__.copt[3]);
-      OpenMM_DoubleArray_set (optCoefficients, 4, polar__.copt[5]);
+      optCoefficients = OpenMM_DoubleArray_create (polar__.cxmax+1);
+      for (int n = 0; n <= polar__.cxmax; n++) {
+        OpenMM_DoubleArray_set (optCoefficients, n, polar__.copt[n]);
+      }
       OpenMM_AmoebaMultipoleForce_setExtrapolationCoefficients
                                   (amoebaMultipoleForce,optCoefficients);
       OpenMM_AmoebaMultipoleForce_setPolarizationType (amoebaMultipoleForce,

--- a/openmm/ommstuff.cpp
+++ b/openmm/ommstuff.cpp
@@ -44,7 +44,7 @@ extern "C" {
    void empole1_ ();
    void enp1_ (double*, double*);
    void ewca1_ (double*);
-   void kinetic_ (double*, double(*)[3][3]); 
+   void kinetic_ (double*, double(*)[3][3], double*); 
    void lattice_ ();
    void mdsave_ (int*, double*, double*, double*);
    void mdstat_ (int*, double*, double*, double*, double*, double*, double*);
@@ -3953,7 +3953,6 @@ void openmm_update_ (void** omm, double* dt, int* istep,
    OpenMMData* openMMDataHandle;
 
    openMMDataHandle = (OpenMMData*) (*omm);
-
    infoMask = OpenMM_State_Positions;
    infoMask += OpenMM_State_Velocities;
    infoMask += OpenMM_State_Forces;    
@@ -4027,14 +4026,12 @@ void openmm_update_ (void** omm, double* dt, int* istep,
    kineticEnergy = (OpenMM_State_getKineticEnergy(state))
                        * OpenMM_KcalPerKJ;
    totalEnergy = potentialEnergy + kineticEnergy;
- 
    if (inform__.debug) {
 
       double eksum, temp, pres;
       double ekin[3][3];
 
-      kinetic_ (&eksum, &ekin);
-      temp = 2.0 * eksum / ((double)(mdstuf__.nfree)*gasconst);
+      kinetic_ (&eksum, &ekin, &temp);
 
       (void) fprintf (stderr, "\n State: E=%15.7e [%15.7e %15.7e]\n",
                       totalEnergy, potentialEnergy, kineticEnergy);
@@ -4060,13 +4057,13 @@ void openmm_update_ (void** omm, double* dt, int* istep,
 
    // make calls to mdstat and/or mdsave if flags are set
 
+
    if (*callMdStat || *callMdSave) {
       double eksum, temp, pres;
       double ekin[3][3];
-      kinetic_ (&eksum, &ekin);
+      kinetic_ (&eksum, &ekin, &temp);
 
       if (*callMdStat) {
-         temp = 2.0 * eksum / ((double)(mdstuf__.nfree)*gasconst);
          pres = 0.0;
          if (bath__.isobaric) {
             lattice_ ();

--- a/openmm/ommstuff.cpp
+++ b/openmm/ommstuff.cpp
@@ -505,10 +505,10 @@ struct {
 } pme__;
 
 struct {
-   int maxxtr;
+   int maxopt;
    int npolar;
    int cxmax;
-   double* cxtr;
+   double* copt;
    double* polarity;
    double* thole;
    double* pdamp;
@@ -520,10 +520,10 @@ struct {
    double* uinp;
    double* uinds;
    double* uinps;
-   double* uxtr;
-   double* uxtrp;
-   double* uxtrs;
-   double* uxtrps;
+   double* uopt;
+   double* uoptp;
+   double* uopts;
+   double* uoptps;
    double* uexact;
    int* douind;
 } polar__;
@@ -1351,18 +1351,18 @@ void set_pme_data_ (int* nfft1, int* nfft2, int* nfft3, int* bsorder,
    pme__.qfac = qfac;
 }
 
-void set_polar_data_ (int* maxxtr, int* npolar, int* cxmax,
-                      double* cxtr, double* polarity, double* thole,
+void set_polar_data_ (int* maxopt, int* npolar, int* cxmax,
+                      double* copt, double* polarity, double* thole,
                       double* pdamp, double* udir, double* udirp,
                       double* udirs, double* udirps, double* uind,
                       double* uinp, double* uinds, double* uinps,
-                      double* uxtr, double* uxtrp, double* uxtrs,
-                      double* uxtrps, double* uexact, int* douind) {
+                      double* uopt, double* uoptp, double* uopts,
+                      double* uoptps, double* uexact, int* douind) {
 
-   polar__.maxxtr = *maxxtr;
+   polar__.maxopt = *maxopt;
    polar__.npolar = *npolar;
    polar__.cxmax = *cxmax;
-   polar__.cxtr = cxtr;
+   polar__.copt = copt;
    polar__.polarity = polarity;
    polar__.thole = thole;
    polar__.pdamp = pdamp;
@@ -1374,10 +1374,10 @@ void set_polar_data_ (int* maxxtr, int* npolar, int* cxmax,
    polar__.uinp = uinp;
    polar__.uinds = uinds;
    polar__.uinps = uinps;
-   polar__.uxtr = uxtr;
-   polar__.uxtrp = uxtrp;
-   polar__.uxtrs = uxtrs;
-   polar__.uxtrps = uxtrps;
+   polar__.uopt = uopt;
+   polar__.uoptp = uoptp;
+   polar__.uopts = uopts;
+   polar__.uoptps = uoptps;
    polar__.uexact = uexact;
    polar__.douind = douind;
 }
@@ -2693,7 +2693,7 @@ static void setupAmoebaMultipoleForce (OpenMM_System* system, FILE* log) {
    OpenMM_IntArray* covalentMap;
    OpenMM_IntArray* gridDimensions;
 
-   OpenMM_DoubleArray* exptCoefficients;
+   OpenMM_DoubleArray* optCoefficients;
 
    double dipoleConversion = OpenMM_NmPerAngstrom;
    double quadrupoleConversion = OpenMM_NmPerAngstrom*OpenMM_NmPerAngstrom;
@@ -2797,14 +2797,15 @@ static void setupAmoebaMultipoleForce (OpenMM_System* system, FILE* log) {
    if (strncasecmp (polpot__.poltyp, "DIRECT", 6) == 0) { 
       OpenMM_AmoebaMultipoleForce_setPolarizationType (amoebaMultipoleForce,
                                    OpenMM_AmoebaMultipoleForce_Direct);
-   } else if (strncasecmp (polpot__.poltyp, "EXTRAP", 6) == 0) {
-      exptCoefficients = OpenMM_DoubleArray_create (4);
-      OpenMM_DoubleArray_set (exptCoefficients, 0, polar__.cxtr[0]);
-      OpenMM_DoubleArray_set (exptCoefficients, 1, polar__.cxtr[1]);
-      OpenMM_DoubleArray_set (exptCoefficients, 2, polar__.cxtr[2]);
-      OpenMM_DoubleArray_set (exptCoefficients, 3, polar__.cxtr[3]);
+   } else if (strncasecmp (polpot__.poltyp, "OPT", 3) == 0) {
+      optCoefficients = OpenMM_DoubleArray_create (5);
+      OpenMM_DoubleArray_set (optCoefficients, 0, polar__.copt[0]);
+      OpenMM_DoubleArray_set (optCoefficients, 1, polar__.copt[1]);
+      OpenMM_DoubleArray_set (optCoefficients, 2, polar__.copt[2]);
+      OpenMM_DoubleArray_set (optCoefficients, 3, polar__.copt[3]);
+      OpenMM_DoubleArray_set (optCoefficients, 4, polar__.copt[5]);
       OpenMM_AmoebaMultipoleForce_setExtrapolationCoefficients
-                                  (amoebaMultipoleForce,exptCoefficients);
+                                  (amoebaMultipoleForce,optCoefficients);
       OpenMM_AmoebaMultipoleForce_setPolarizationType (amoebaMultipoleForce,
                                    OpenMM_AmoebaMultipoleForce_Extrapolated);
    } else {


### PR DESCRIPTION
The latest version of TINKER does not work with OpenMM, due to some variable names changing and a function signature change.  This patch restores the interface.